### PR TITLE
Update library versions and specify source set for display in AS Android project panel

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -3,11 +3,11 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-kapt'
 
 android {
-    compileSdkVersion 26
+    compileSdkVersion 27
     defaultConfig {
         applicationId "pl.pszklarska.livedatabinding"
         minSdkVersion 21
-        targetSdkVersion 26
+        targetSdkVersion 27
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
@@ -21,15 +21,18 @@ android {
     dataBinding {
         enabled = true
     }
+    sourceSets {
+        main.java.srcDirs += 'src/main/kotlin'
+    }
 }
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation 'com.android.support:appcompat-v7:26.1.0'
-    implementation 'android.arch.lifecycle:extensions:1.0.0'
+    implementation 'com.android.support:appcompat-v7:27.0.2'
+    implementation 'android.arch.lifecycle:extensions:1.1.0'
 
-    kapt 'com.android.databinding:compiler:3.1.0-alpha06'
-    kapt 'android.arch.lifecycle:compiler:1.0.0'
+    kapt 'com.android.databinding:compiler:3.1.0-alpha09'
+    kapt 'android.arch.lifecycle:compiler:1.1.0'
 
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'com.android.support.test:runner:1.0.1'

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-	    classpath 'com.android.tools.build:gradle:3.1.0-alpha06'
+	    classpath 'com.android.tools.build:gradle:3.1.0-alpha09'
 	    classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Dec 23 21:04:46 CET 2017
+#Fri Jan 26 15:52:57 CET 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-rc-3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip


### PR DESCRIPTION
When I checked out the project into the most recent Android Studio Preview version (3.1 Canary 9) I had to update a few libraries. I also had to specify the source set as otherwise the classes wouldn't appear in the Android Studio project panel when switched to the Android view.